### PR TITLE
Remove "__esModule" flag

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,7 @@
 import {EventStation} from './models/EventStation';
 
+/* Set properties for module loader compatibility */
 (<any>EventStation).EventStation = EventStation;
 (<any>EventStation).default = EventStation;
-
-Object.defineProperty(EventStation, '__esModule', { value: true });
 
 export default EventStation;


### PR DESCRIPTION
The "__esModule" flag is added by transpilers to alter how module
loaders handle default exports. Adding it in the source is causing issues,
e.g. system.js throws an error.

The flag isn't necessary since the module already sets additional
properties for module loader compatibility.