### PR TITLE
Emission fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@morrisallison/tslint-config": "^0.1.0",
+    "@morrisallison/tslint-config": "^0.1.2",
     "@types/node": "^7.0.5",
     "benchmark": "^2.1.3",
     "bluebird": "^3.4.7",

--- a/src/actions/applyListeners.ts
+++ b/src/actions/applyListeners.ts
@@ -18,6 +18,9 @@ export function applyListeners<P extends Promise<any>>(
     const promises: P[] = [];
     let result: P | void;
 
+    /* Clone array to prevent mutation */
+    listeners = listeners.slice();
+
     for (const listener of listeners) {
 
         if (stationMeta.isPropagationStopped) {

--- a/tslint.json
+++ b/tslint.json
@@ -1,9 +1,3 @@
 {
-    "extends": "@morrisallison/tslint-config",
-    "rulesDirectory": [
-        "node_modules/@morrisallison/tslint-config/rules",
-        "node_modules/tslint-eslint-rules/dist/rules",
-        "node_modules/tslint-microsoft-contrib",
-        "node_modules/vrsource-tslint-rules/rules"
-    ]
+    "extends": "@morrisallison/tslint-config"
 }


### PR DESCRIPTION
During event emission, if listeners are detached from an emitter, it was possible that the listener array in `applyListeners` could be mutated. This resulted in some listeners being skipped.