### PR TITLE
Permit use with node >8

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
     }
   },
   "engines": {
-    "node": "^8.0.0",
-    "npm": "^5.0.0"
+    "node": ">=8.0.0",
+    "npm": ">=5.0.0"
   },
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
Yarn won't add this to a project using node v9.x